### PR TITLE
feat: Ignore ACTIVATE_VERSION as it doesn't make sense in the context of jsonl files

### DIFF
--- a/target_singer_jsonl/__init__.py
+++ b/target_singer_jsonl/__init__.py
@@ -192,6 +192,10 @@ def persist_lines(config, lines):
             logger.debug(f'Setting state to {message["value"]}')
             state = message["value"]
 
+        elif t == "ACTIVATE_VERSION":
+            # ignore ACTIVATE_VERSION as it doesn't make sense in the context of jsonl files
+            pass
+
         else:
             raise Exception(f"Unknown message type {t} in message {message}")
 


### PR DESCRIPTION
I feel it's better than outright failing when seeing an `ACTIVATE_VERSION` message.